### PR TITLE
Feature/digest email command

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,6 +1,17 @@
 import factory
 
 
+class UserFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = 'auth.User'
+
+    first_name = 'Test'
+    last_name = 'User'
+    username = factory.Sequence(lambda n: 'user_{0}'.format(n))
+    email = factory.Sequence(lambda n: 'user_{0}@maykinmedia.nl'.format(n))
+    password = factory.PostGenerationMethodCall('set_password', 'testing')
+
+
 class ArticleFactory(factory.django.DjangoModelFactory):
 
     class Meta:

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -15,5 +15,6 @@ INSTALLED_APPS = [
     'tests'
 ]
 
+EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
 
 ROOT_URLCONF = 'tests.test_urls'

--- a/tests/test_management_commands.py
+++ b/tests/test_management_commands.py
@@ -1,0 +1,145 @@
+from datetime import timedelta
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+from django.conf import settings
+from django.core import mail
+from django.core.management import call_command, CommandError
+from django.test import override_settings, TestCase
+from django.utils import timezone
+
+from timeline_logger.models import TimelineLog
+from .factories import ArticleFactory, UserFactory
+
+
+class ReportMailingTestCase(TestCase):
+    def setUp(self):
+        self.article = ArticleFactory.create()
+
+        self.user = UserFactory.create(email='jose@maykinmedia.nl')
+        self.staff_user = UserFactory.create(is_staff=True)
+        self.admin_user = UserFactory.create(is_staff=True, is_superuser=True)
+
+        self.log_1 = TimelineLog.objects.create(
+            content_object=self.article,
+            user=self.user,
+        )
+        self.log_2 = TimelineLog.objects.create(
+            content_object=self.article,
+            user=self.user,
+        )
+        self.log_3 = TimelineLog.objects.create(
+            content_object=self.article,
+            user=self.user,
+        )
+
+    @override_settings(TIMELINE_DIGEST_EMAIL_RECIPIENTS=['jose@maykinmedia.nl'])
+    def test_recipients_from_setting_parameter(self):
+        """
+        The ``--recipients-from-setting`` parameter will send notifications
+        only to those users listed in the ``TIMELINE_DIGEST_EMAIL_RECIPIENTS``
+        setting.
+        """
+        call_command('report_mailing', '--recipients-from-setting')
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertListEqual(mail.outbox[0].to, settings.TIMELINE_DIGEST_EMAIL_RECIPIENTS)
+
+    def test_staff_parameter(self):
+        """
+        The ``--staff`` parameter will send notifications only to those users
+        marked who have ``is_staff=True``.
+        """
+        call_command('report_mailing', '--staff')
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertListEqual(mail.outbox[0].to, [self.staff_user.email, self.admin_user.email])
+
+    def test_all_parameter(self):
+        """
+        The ``--all`` parameter will send notifications to all users.
+        """
+        call_command('report_mailing', '--all')
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertListEqual(mail.outbox[0].to, [self.user.email, self.staff_user.email, self.admin_user.email])
+
+    def test_no_recipients_parameter(self):
+        """
+        When no 'recipients' parameter is passed, only those users who are
+        'staff' and 'superuser' will be notified.
+        """
+        call_command('report_mailing')
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertListEqual(mail.outbox[0].to, [self.admin_user.email])
+
+    def test_invalid_days_parameter(self):
+        """
+        The ``--days`` parameter must be an integer, representing the number of
+        days until today.
+        """
+        self.assertRaisesMessage(
+            CommandError,
+            "Incorrect 'days' parameter. 'days' must be a number of days.",
+            call_command,
+            'report_mailing', days='NaN'
+        )
+
+    def test_days_parameter_successful(self):
+        """
+        The ``--days`` parameter will restrict the logs to only those generated
+        from today until the number of days before passed in the parameter.
+        """
+        # Change the timestamp of the existing logs in order to test this.
+        self.log_1.timestamp = timezone.now() - timedelta(days=30)
+        self.log_2.timestamp = timezone.now() - timedelta(days=10)
+        self.log_1.save()
+        self.log_2.save()
+
+        call_command('report_mailing', days=15)
+
+        self.assertEqual(len(mail.outbox), 1)
+
+        # The 1st log `self.log_1` is NOT present in the email, because it was
+        # generated before 15 days ago from today.
+        self.assertNotIn(self.log_1.timestamp.strftime('%B %d, %Y'), mail.outbox[0].body)
+
+        # The other logs `self.log_2` and `self.log_3` are properly
+        self.assertIn(self.log_2.timestamp.strftime('%B %d, %Y'), mail.outbox[0].body)
+        self.assertIn(self.log_3.timestamp.strftime('%B %d, %Y'), mail.outbox[0].body)
+
+    def test_no_logs_recorded(self):
+        """
+        The command will do nothing if there are no logs at all.
+        """
+        # Get rid of all the existent logs.
+        TimelineLog.objects.all().delete()
+
+        call_command('report_mailing')
+
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_no_timeline_digest_from_email_setting(self):
+        """
+        If the ``TIMELINE_DIGEST_FROM_EMAIL`` setting is not set, the backend
+        will default to the Django's standard ``DEFAULT_FROM_EMAIL`` setting.
+        """
+        call_command('report_mailing')
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
+
+    @override_settings(TIMELINE_DIGEST_FROM_EMAIL='reports@maykinmedia.nl')
+    def test_timeline_digest_from_email_setting(self):
+        """
+        If the ``TIMELINE_DIGEST_FROM_EMAIL`` setting is not set, the backend
+        will default to the Django's standard ``DEFAULT_FROM_EMAIL`` setting.
+        """
+        call_command('report_mailing')
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].from_email, settings.TIMELINE_DIGEST_FROM_EMAIL)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,22 +7,14 @@ from django.contrib.auth.models import User
 from django.template.exceptions import TemplateDoesNotExist
 from django.template.defaultfilters import date
 from django.test import RequestFactory, TestCase
-from django.utils import timezone
 
 from timeline_logger.models import TimelineLog
-from .models import Article
+from .factories import ArticleFactory
 
 
 class TimelineLogTestCase(TestCase):
     def setUp(self):
-        self.article = Article.objects.create(
-            title='Data Analysis with Python',
-            abstract='An approach to data analysis using Python programming language.',
-            date=timezone.now().date(),
-            authors='José L. Patiño, Jos Vromans',
-            body='Here we will talk about something related to data analysis.',
-            bibliography="Python for Data Analysis, Wes McKinney, O'Reilly"
-        )
+        self.article = ArticleFactory.create()
 
         self.user = User.objects.create(username='john_doe', email='john.doe@maykinmedia.nl')
 

--- a/timeline_logger/compat.py
+++ b/timeline_logger/compat.py
@@ -1,0 +1,15 @@
+import sys
+
+
+# Safely importing the HTML parser utility, highly dependent on Python versions
+if sys.version_info >= (3, 4):
+    # From v3.4.0 in advance
+    import html
+elif (3, 0) < sys.version_info < (3, 4):
+    # From v3.0 until 3.3
+    from html.parser import HTMLParser
+    html = HTMLParser()
+else:
+    # Python 2.x versions
+    from HTMLParser import HTMLParser
+    html = HTMLParser()

--- a/timeline_logger/conf.py
+++ b/timeline_logger/conf.py
@@ -16,6 +16,7 @@ class TimelineLoggerConf(AppConf):
 
     DIGEST_EMAIL_RECIPIENTS = None
     DIGEST_EMAIL_SUBJECT = _('Events timeline')
+    DIGEST_FROM_EMAIL = None
 
     class Meta:
         prefix = 'timeline'
@@ -23,4 +24,9 @@ class TimelineLoggerConf(AppConf):
     def configure_digest_email_recipients(self, value):
         if value is None:
             return []
+        return value
+
+    def configure_digest_from_email(self, value):
+        if value is None:
+            return settings.DEFAULT_FROM_EMAIL
         return value

--- a/timeline_logger/management/commands/report_mailing.py
+++ b/timeline_logger/management/commands/report_mailing.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             '--days', type=int,
-            help='An integer number with the number of days to look at from today.'
+            help='An integer number with the number of days to look at from today to the past.'
         )
 
         recipients_group = parser.add_mutually_exclusive_group()
@@ -53,7 +53,7 @@ class Command(BaseCommand):
             try:
                 start = timezone.now() - timedelta(days=days)
             except TypeError:
-                raise CommandError("Incorrect 'start' parameter. 'start' must be a number of days.")
+                raise CommandError("Incorrect 'days' parameter. 'days' must be a number of days.")
             else:
                 queryset = queryset.filter(timestamp__gte=start)
 
@@ -71,7 +71,7 @@ class Command(BaseCommand):
         send_mail(
             subject=settings.TIMELINE_DIGEST_EMAIL_SUBJECT,
             message=text_content,
-            from_email=settings.DEFAULT_FROM_EMAIL,
+            from_email=settings.TIMELINE_DIGEST_FROM_EMAIL,
             recipient_list=recipients,
             fail_silently=False,
             html_message=html_content

--- a/timeline_logger/management/commands/report_mailing.py
+++ b/timeline_logger/management/commands/report_mailing.py
@@ -1,20 +1,5 @@
 import logging
-import sys
 from datetime import timedelta
-
-
-# Safely importing the HTML parser utility, highly dependent on Python versions
-if sys.version_info >= (3, 4):
-    # From v3.4.0 in advance
-    import html
-elif (3, 0) < sys.version_info < (3, 4):
-    # From v3.0 until 3.3
-    from html.parser import HTMLParser
-    html = HTMLParser()
-else:
-    # Python 2.x versions
-    from HTMLParser import HTMLParser
-    html = HTMLParser()
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -25,6 +10,7 @@ from django.utils import timezone
 from django.utils.html import strip_tags
 from django.utils.translation import ugettext_lazy as _
 
+from timeline_logger.compat import html
 from timeline_logger.models import TimelineLog
 
 

--- a/timeline_logger/management/commands/report_mailing.py
+++ b/timeline_logger/management/commands/report_mailing.py
@@ -1,6 +1,20 @@
-import html
 import logging
+import sys
 from datetime import timedelta
+
+
+# Safely importing the HTML parser utility, highly dependent on Python versions
+if sys.version_info >= (3, 4):
+    # From v3.4.0 in advance
+    import html
+elif (3, 0) < sys.version_info < (3, 4):
+    # From v3.0 until 3.3
+    from html.parser import HTMLParser
+    html = HTMLParser()
+else:
+    # Python 2.x versions
+    from HTMLParser import HTMLParser
+    html = HTMLParser()
 
 from django.conf import settings
 from django.contrib.auth import get_user_model

--- a/timeline_logger/templatetags/timeline.py
+++ b/timeline_logger/templatetags/timeline.py
@@ -1,7 +1,7 @@
-from django import template
+from django.template import Library
 
 
-register = template.Library()
+register = Library()
 
 
 @register.simple_tag


### PR DESCRIPTION
- Added `DIGEST_FROM_EMAIL` setting - It allows the programmer to define a specific email for the notifications sender, otherwise defaults to Django's custom `DEFAULT_FROM_EMAIL`.
- Fixed imports bug in `report_mailing` module.
- Test case for the `report_mailing` management command.
