### PR TITLE
Add a queue and background-thread based logging handler

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ Contents
 
    installation
    usage
+   logging_integration
    sending_log_reports
    settings
    contributing

--- a/docs/logging_integration.rst
+++ b/docs/logging_integration.rst
@@ -1,0 +1,236 @@
+.. _stdlib_logging_integration:
+
+==========================
+Stdlib logging integration
+==========================
+
+Python has a standard library `logging <https://docs.python.org/3.12/library/logging.html>`_
+module that's commonly used in projects and external packages.
+
+`Structlog <https://www.structlog.org/en/stable/index.html>`_ builds on top of this and
+adds structure to your log messages/events.
+
+Django-timeline-logger brings these worlds together - it supports saving log records
+created through structlog into the database (to the :class:`timeline_logger.models.TimelineLog`
+model), and it does this by configuring the standard library logging mechanisms.
+
+.. warning:: The log message (``logging.LogRecord.msg``) must be a dictionary -
+   string-based log messages are not supported.
+
+Configuration
+=============
+
+**Settings**
+
+To use the integration, you must define a handler in the Django ``LOGGING``
+configuration, and direct logs from your logger(s) to this handler. For example:
+
+.. code-block:: python
+    :linenos:
+    :emphasize-lines: 3, 27-33, 38
+
+    import structlog
+
+    from my_project.logging import adapter
+
+    LOGGING = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "json": {
+                "()": structlog.stdlib.ProcessorFormatter,
+                "processor": structlog.processors.JSONRenderer(),
+                "foreign_pre_chain": [
+                    structlog.contextvars.merge_contextvars,
+                    structlog.processors.TimeStamper(fmt="iso"),
+                    structlog.stdlib.add_logger_name,
+                    structlog.stdlib.add_log_level,
+                    structlog.stdlib.PositionalArgumentsFormatter(),
+                ],
+            },
+        },
+        "handlers": {
+            "console": {
+                "level": "DEBUG",
+                "class": "logging.StreamHandler",
+                "formatter": "json",
+            },
+            "timeline_logger": {
+                "level": "DEBUG",
+                "()": "timeline_logger.handlers.timeline_handler_factory",
+                "adapter": adapter,  # see below for example
+                "buffer_size": 15,
+                "flush_interval": 15.0,  # in seconds
+            },
+        },
+        "loggers": {
+            "audit": {
+                # log both stdout/stderr and the database
+                "handlers": ["console", "timeline_logger"],
+                "level": "DEBUG",
+                "propagate": False,
+            },
+        },
+    }
+
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.stdlib.filter_by_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.UnicodeDecoder(),
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
+**Adapter callback**
+
+The adapter callback is a function that takes a structlog
+:class:`timeline_logger.typing.EventDict` and transforms it into an object that carries
+the database model details. For example:
+
+.. code-block:: python
+
+    from structlog.typing import EventDict
+    from timeline_logger.typing import EventDetailsProtocol
+
+
+    @dataclass
+    class EventDetails(EventDetailsProtocol):
+        instance: models.Model
+        user: User | None
+        extra_data: Mapping[str, object]
+
+        def get_template_name(self) -> str:
+            return "timeline_logger/default.txt"
+
+        def get_user(self) -> User | None:
+            return self.user
+
+        def get_extra_data(self) -> Mapping[str, object]:
+            return self.extra_data
+
+
+    def adapter(event_dict: EventDict) -> EventDetails | None:
+        from django.contrib.auth.models import User
+
+        assert "event" in event_dict
+
+        match event_dict:
+            case {
+                "event": "user_viewed_pii" as event,
+                "user": str(viewer_username),
+                "subject": str(subject_username),
+            }:
+                subject = User.objects.get(username=subject_username)
+                viewer = User.objects.get(username=viewer_username)
+                return EventDetails(
+                    instance=subject,
+                    user=viewer,
+                    extra_data={"event": event},
+                )
+            case _:
+                return None
+
+**Usage**
+
+You can then use your logger as usual:
+
+.. code-block:: python
+
+    import structlog
+
+    audit_logger = structlog.stdlib.get_logger("audit")
+
+    audit_logger.info(
+        "user_viewed_pii",
+        user=request.user.username,
+        subject=subject.username,
+    )
+
+and the events will be written to the database.
+
+How it works
+============
+
+When django initializes, it sets up logging. Typically this results in
+``logging.config.dictConfig`` being called with your Django ``LOGGING`` setting.
+
+This leads to ``timeline_handler_factory`` being called, which initializes and
+configures the appropriate handler. In queue mode (enabled by default), a background
+thread will start that reads from a queue. The ``StructlogQueueHandler`` is configured
+with this queue, and any log event that arrives is offloaded to the worker thread.
+
+``TimelineLoggerHandler`` runs in the worker thread and continuously reads from the
+queue. When a log event arrives, it is passed to the configured ``adapter`` callback.
+This adapter is responsible for transforming the log event into something
+``TimelineLog`` understands - or ``None`` to skip saving it entirely.
+
+The resulting ``TimelineLog`` instance is added to an internal buffer. The buffer is
+written to the database once enough items have arrived or the configured flush interval
+has elapsed.
+
+Because the writes happen in a worker thread, these use a separate database transaction,
+and you can never lose log records because of rolled back transactions in the main
+thread.
+
+Testing
+=======
+
+Set:
+
+.. code-block:: python
+
+    TIMELINE_HANDLER_USE_QUEUE = False
+
+when running your Django test suite. It will skip the thread and queue for log messages,
+and synchronously insert the log events in the database. This will all happen in the
+same database transaction that your test is currently running in, so at the end of the
+test when the transaction is rolled back, your log events are rolled back too. This
+prevents broken isolation between tests.
+
+If, for some reason, you need to enable the thread-based logging, you should use a
+``TransactionTestCase``, but be warned - these are much slower.
+
+.. note:: This setting is global and cannot be changed on an individual test-basis,
+   because Django only configures logging once when it initializes.
+
+Third-party packages support
+============================
+
+Many third party packages should work out of the box. However, you will probably
+encounter issues like deadlocks on tools that make use of process forking
+(``os.fork()``), because we start a background thread for the log handling.
+
+Packages known to be problematic and their support + specific instructions are
+documented here.
+
+uWSGI
+-----
+
+uWSGI forks worker processes. We handle uwsgi already out of the box by detecting
+whether we're running in a uwsgi context or not. The background threads are started
+only after the master process has forked.
+
+Using the ``--lazy-apps`` options may also avoid the issue in the first place.
+
+Celery worker
+-------------
+
+Celery workers by default use a process pool, where worker processes are spawned by the
+main process. When starting Celery worker in prefork mode, make sure that you set the
+environment variable:
+
+.. code-block:: sh
+
+    _TIMELINE_LOGGER_DEFER_LISTENER=true celery --app myapp worker
+
+We listen and wait for the ``worker_process_init`` signal to start the background
+thread.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -4,23 +4,22 @@
 Usage
 =====
 
-Django Timeline Logger works by using a custom model ``TimelineLog``, which is
-designed to store:
+Django Timeline Logger provides a database model and table to store log events and
+their context. The model tracks:
 
-    - A Django model instance (a database object).
-    - A timestamp.
-    - A user instance (optional).
-    - A path to a template (optional, defaults to ``timeline_logger/default.txt``).
-    - A context (optional).
+* The Django model instance (database object) the log event is about.
+* Timestamp of when the log entry was created.
+* User instance related to the log event (optional).
+* Optional path to a Django template used for renderingen the log message (defaults to
+  ``timeline_logger/default.txt``).
+* Arbitrary context data, stored as JSON (optional).
 
-Given those details, it's pretty clear how it works: whenever you want to log
-an event in your system, you create a ``TimelineLog`` for it, passing the data
-you consider useful in the context and using a template to render the message.
+In *manual* mode, the package allows you to create ``TimelineLog`` entries whenever you
+want to log an event in your system by passing the relevant context, and you specify
+which template to render use to render the message.
 
-The context is stored in a ``django.db.models.JSONField``, which accepts a
-Python dictionary representing JSON data, to be built by you with the data you
-want to pass to the message template.
-
+.. tip:: You can also use structlog log events and send them to the database, see
+   :ref:`stdlib_logging_integration`.
 
 Default example
 ===============
@@ -170,5 +169,5 @@ Django-timeline-logger ships with a ``ModelResource``:
 
     ...
 
- It's not enabled in the default admin, as django-import-export is an
- optional dependency.
+It's not enabled in the default admin, as django-import-export is an
+optional dependency.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ requires-python = ">=3.12"
 dependencies = [
     "django>=4.2",
     "django-appconf",
+    "typing-extensions",
 ]
 
 [project.urls]
@@ -48,6 +49,7 @@ tests = [
     "psycopg",
     "pytest",
     "pytest-cov",
+    "pytest-env",
     "pytest-django",
     "tox",
     "ruff",
@@ -67,6 +69,12 @@ namespaces = false
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 DJANGO_SETTINGS_MODULE = "tests.settings_pg"
+markers = [
+    "real_db_close: do not patch timeline_logger.handlers.close_old_connections",
+]
+env = [
+    "_TIMELINE_LOGGER_DEFER_LISTENER=true",
+]
 
 [tool.bumpversion]
 current_version = "5.0.0"

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,15 +1,23 @@
+from django.contrib.auth.models import User
+
 import factory
 
 
-class UserFactory(factory.django.DjangoModelFactory):
+class UserFactory(factory.django.DjangoModelFactory[User]):
     first_name = "Test"
     last_name = "User"
     username = factory.Sequence(lambda n: f"user_{n}")
     email = factory.Sequence(lambda n: f"user_{n}@maykinmedia.nl")
-    password = factory.PostGenerationMethodCall("set_password", "testing")
 
     class Meta:
         model = "auth.User"
+        skip_postgeneration_save = True
+
+    @factory.post_generation
+    def password(obj: User, create, extracted, **kwargs):
+        obj.set_password(extracted or "testing")
+        if create:
+            obj.save()
 
 
 class ArticleFactory(factory.django.DjangoModelFactory):

--- a/tests/test_log_handlers.py
+++ b/tests/test_log_handlers.py
@@ -1,0 +1,297 @@
+import logging
+import logging.config
+import time
+import uuid
+from collections.abc import Mapping
+from contextlib import nullcontext
+from dataclasses import dataclass
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.db import models
+
+import pytest
+
+from timeline_logger.handlers import (
+    StructlogQueueHandler,
+    TimelineLoggerHandler,
+    _queue,
+    _stop_listener,
+    get_listener,
+    timeline_handler_factory,
+)
+from timeline_logger.models import TimelineLog
+from timeline_logger.typing import EventDetailsProtocol, EventDict
+
+
+@dataclass
+class EventDetails(EventDetailsProtocol):
+    instance: models.Model
+    extra_data: Mapping[str, object]
+
+    def get_template_name(self) -> str:
+        return "dummy.txt"
+
+    def get_user(self) -> User | None:
+        return None
+
+    def get_extra_data(self) -> Mapping[str, object]:
+        return self.extra_data
+
+
+def assert_background_thread_not_running():
+    assert get_listener() is None
+
+
+@pytest.fixture(autouse=True)
+def test_setup_and_teardown(request: pytest.FixtureRequest):
+    # prevent connections from being closed for real, since tests run in a transaction
+    # and require an open connection for further assertions
+    use_real_close_conns = request.node.get_closest_marker("real_db_close")
+    patch_context = (
+        nullcontext()
+        if use_real_close_conns
+        else patch("timeline_logger.handlers.close_old_connections")
+    )
+    with patch_context:
+        yield
+    _stop_listener()
+
+
+@pytest.fixture
+def log_record() -> logging.LogRecord:
+    return logging.LogRecord(
+        name="timeline",
+        level=logging.DEBUG,
+        pathname=__file__,
+        lineno=1,
+        msg={"event": "dummy"},
+        args=None,
+        exc_info=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "use_queue,expected",
+    [
+        (False, TimelineLoggerHandler),
+        (True, StructlogQueueHandler),
+    ],
+)
+def test_build_expected_instance_based_on_setting(
+    settings, use_queue: bool, expected: type[logging.Handler]
+):
+    settings.TIMELINE_HANDLER_USE_QUEUE = use_queue
+
+    handler = timeline_handler_factory(adapter=lambda event_dict: None)
+
+    assert isinstance(handler, expected)
+    assert_background_thread_not_running()
+
+
+@pytest.mark.django_db
+def test_handler_flushes_immediately_in_non_queue_mode(
+    admin_user: User, log_record: logging.LogRecord
+):
+    handler = TimelineLoggerHandler(
+        adapter=lambda event_dict: EventDetails(
+            instance=admin_user, extra_data=event_dict
+        ),
+        buffer_size=1000,
+        flush_interval=999,
+        use_queue_mode=False,
+    )
+
+    result = handler.handle(log_record)
+
+    assert result is not False
+    logs = TimelineLog.objects.for_object(admin_user)
+    assert len(logs) == 1
+    assert logs[0].template == "dummy.txt"
+    assert logs[0].extra_data == {"event": "dummy"}
+
+
+@pytest.mark.django_db
+def test_handler_flushes_in_queue_mode_when_buffer_size_limit_reached(
+    admin_user: User,
+    log_record: logging.LogRecord,
+    subtests: pytest.Subtests,
+):
+    handler = TimelineLoggerHandler(
+        adapter=lambda event_dict: EventDetails(
+            instance=admin_user, extra_data=event_dict
+        ),
+        buffer_size=2,
+        flush_interval=999,
+        use_queue_mode=True,
+    )
+
+    with subtests.test("buffer not yet full"):
+        result = handler.handle(log_record)
+
+        assert result is not False
+        logs = TimelineLog.objects.for_object(admin_user)
+        assert len(logs) == 0
+
+    with subtests.test("buffer full"):
+        result = handler.handle(log_record)
+
+        assert result is not False
+        logs = TimelineLog.objects.for_object(admin_user)
+        assert len(logs) == 2
+
+
+@pytest.mark.django_db
+def test_handler_flushes_in_queue_mode_when_flush_interval_is_exceeded(
+    admin_user: User,
+    log_record: logging.LogRecord,
+    subtests: pytest.Subtests,
+):
+    handler = TimelineLoggerHandler(
+        adapter=lambda event_dict: EventDetails(
+            instance=admin_user, extra_data=event_dict
+        ),
+        buffer_size=999,
+        flush_interval=0.5,
+        use_queue_mode=True,
+    )
+
+    with subtests.test("buffer not full, last write recent enough"):
+        result = handler.handle(log_record)
+
+        assert result is not False
+        logs = TimelineLog.objects.for_object(admin_user)
+        assert len(logs) == 0
+
+    time.sleep(0.5)
+
+    with subtests.test("buffer not full, last write too long ago"):
+        result = handler.handle(log_record)
+
+        assert result is not False
+        logs = TimelineLog.objects.for_object(admin_user)
+        assert len(logs) == 2
+
+
+@pytest.mark.django_db
+def test_closing_handler_flushes_the_queue(
+    admin_user: User, log_record: logging.LogRecord
+):
+    handler = TimelineLoggerHandler(
+        adapter=lambda event_dict: EventDetails(
+            instance=admin_user, extra_data=event_dict
+        ),
+        buffer_size=999,
+        flush_interval=999,
+        use_queue_mode=True,
+    )
+    result = handler.handle(log_record)
+
+    assert result is not False
+    assert not TimelineLog.objects.exists()
+
+    handler.close()
+
+    assert TimelineLog.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_handler_adapter_can_return_None_when_nothing_needs_to_be_logged(
+    log_record: logging.LogRecord,
+):
+    handler = TimelineLoggerHandler(
+        adapter=lambda event_dict: None,
+        buffer_size=999,
+        flush_interval=999,
+        use_queue_mode=False,
+    )
+
+    result = handler.handle(log_record)
+
+    assert result is not False
+    assert not TimelineLog.objects.exists()
+
+
+@pytest.mark.django_db
+def test_handler_can_be_disabled_with_setting(
+    settings,
+    admin_user: User,
+    log_record: logging.LogRecord,
+):
+    settings.TIMELINE_HANDLER_DISABLED = True
+    handler = TimelineLoggerHandler(
+        adapter=lambda event_dict: EventDetails(
+            instance=admin_user, extra_data=event_dict
+        ),
+        buffer_size=999,
+        flush_interval=999,
+        use_queue_mode=False,
+    )
+
+    result = handler.handle(log_record)
+
+    assert result is not False
+    assert not TimelineLog.objects.exists()
+
+
+@pytest.mark.django_db
+def test_handler_suppresses_unknown_errors(log_record: logging.LogRecord):
+    def _raise(event_dict: EventDict):
+        raise Exception("oof")
+
+    handler = TimelineLoggerHandler(adapter=_raise, use_queue_mode=False)
+
+    result = handler.handle(log_record)
+
+    assert result is not False
+    assert not TimelineLog.objects.exists()
+
+
+@pytest.mark.real_db_close
+@pytest.mark.django_db(transaction=True)
+def test_integration_via_logging_dictconfig(
+    settings,
+    admin_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    settings.TIMELINE_HANDLER_USE_QUEUE = True
+    monkeypatch.setenv("_TIMELINE_LOGGER_DEFER_LISTENER", "false")
+
+    # set up a logger/handler only for this test to not break isolation/affect pytests
+    # logging setup.
+    logger_name = str(uuid.uuid4())
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "handlers": {
+                logger_name: {
+                    "level": "DEBUG",
+                    "()": "timeline_logger.handlers.timeline_handler_factory",
+                    "adapter": lambda event_dict: EventDetails(
+                        instance=admin_user, extra_data=event_dict
+                    ),
+                    "buffer_size": 1,  # force immediate flush
+                    "flush_interval": 1,
+                },
+            },
+            "loggers": {
+                logger_name: {
+                    "handlers": [logger_name],
+                    "level": "DEBUG",
+                    "propagate": False,
+                }
+            },
+        }
+    )
+    logger = logging.getLogger(logger_name)
+    assert get_listener() is not None
+
+    logger.info({"event": "test-event"})
+
+    _queue.join()
+
+    assert TimelineLog.objects.count() == 1
+    log_obj = TimelineLog.objects.get()
+    assert log_obj.content_object == admin_user
+    assert log_obj.extra_data == {"event": "test-event"}

--- a/tests/test_log_handlers.py
+++ b/tests/test_log_handlers.py
@@ -247,6 +247,25 @@ def test_handler_suppresses_unknown_errors(log_record: logging.LogRecord):
     assert not TimelineLog.objects.exists()
 
 
+@pytest.mark.django_db
+def test_handler_calls_on_error_callback_if_provided(
+    settings, log_record: logging.LogRecord
+):
+    errors_seen: set[Exception] = set()
+    settings.TIMELINE_HANDLER_ON_ERROR = lambda err: errors_seen.add(err)
+
+    def _raise(event_dict: EventDict):
+        raise Exception("oof")
+
+    handler = TimelineLoggerHandler(adapter=_raise, use_queue_mode=False)
+
+    result = handler.handle(log_record)
+
+    assert result is not False
+    assert len(errors_seen) == 1
+    assert errors_seen.pop().args[0] == "oof"
+
+
 @pytest.mark.real_db_close
 @pytest.mark.django_db(transaction=True)
 def test_integration_via_logging_dictconfig(

--- a/timeline_logger/conf.py
+++ b/timeline_logger/conf.py
@@ -17,6 +17,7 @@ class TimelineLoggerConf(AppConf):
 
     HANDLER_DISABLED = False
     HANDLER_USE_QUEUE = True
+    HANDLER_ON_ERROR = None
 
     class Meta:
         prefix = "timeline"

--- a/timeline_logger/conf.py
+++ b/timeline_logger/conf.py
@@ -15,6 +15,9 @@ class TimelineLoggerConf(AppConf):
     DIGEST_EMAIL_SUBJECT = _("Events timeline")
     DIGEST_FROM_EMAIL = None
 
+    HANDLER_DISABLED = False
+    HANDLER_USE_QUEUE = True
+
     class Meta:
         prefix = "timeline"
 

--- a/timeline_logger/handlers.py
+++ b/timeline_logger/handlers.py
@@ -1,0 +1,360 @@
+"""
+Provide robust and opinionated logging handlers.
+
+`Log handlers <https://docs.python.org/3.12/library/logging.html#handler-objects>`_ are
+responsible for sending the actual log records produced by loggers to their final
+destination.
+
+django-timeline-logger provides a handler that knows how to send log records from
+structlog to the database and save them into the
+:class:`timeline_logger.models.TimelineLog` model.
+
+Our handler implementations take care of packages/modules that rely on process-forking
+behaviour, notably:
+
+* uwsgi
+* celery workers with prefork pool
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+import queue
+import threading
+import time
+from collections.abc import Callable
+from contextlib import contextmanager
+from logging.handlers import QueueHandler, QueueListener
+from typing import TYPE_CHECKING, Any
+
+from django.db import close_old_connections
+from django.utils.module_loading import import_string
+
+from .conf import settings
+from .typing import Adapter, EventDict, is_event_dict
+
+if TYPE_CHECKING:
+    from .models import TimelineLog
+
+# public API
+__all__ = ["TimelineLoggerHandler", "timeline_handler_factory"]
+
+postfork: Callable[[Callable[..., Any]], Any]
+
+# the uwsgi module is special - it's only available when the python code is loaded
+# through uwsgi. With regular ``python`` usage, it does not exist.
+try:  # pragma: no cover
+    import uwsgi  # pyright: ignore[reportMissingModuleSource]
+    from uwsgidecorators import postfork  # pyright: ignore[reportMissingModuleSource]
+except ImportError:
+    uwsgi = None
+    postfork = lambda cb: None  # noqa: E731
+
+
+logger = logging.getLogger(__name__)
+
+_queue: queue.Queue = queue.Queue[EventDict](maxsize=0)
+"""
+Global queue singleton for the StructlogQueueHandler and QueueListener to communicate.
+
+The queue is unbounded per the recommendations on an
+`online article <https://runebook.dev/en/docs/python/library/logging.handlers/logging.handlers.QueueListener>`_.
+
+TODO: it would probably be wise to monitor the queue size or when items get put on/taken
+from the queue, e.g. with an OTel gauge instrument.
+"""
+
+_listener: QueueListener | None = None
+"""
+Queue listener singleton, ``None`` when it's not yet initialized.
+
+Usually, the handler factory will result in the listener being initialized, but in
+process-forking environments like uwsgi and celery workers, this is deferred until
+after the process has forked. Failing to defer this results in deadlocks or other odd
+behaviours.
+"""
+
+_lock = threading.Lock()
+"""
+Protect against race conditions between threads.
+
+Trying to acquire a locked lock will block until it's unlocked (by another thread).
+
+Note that Django's runserver runs in a subprocess, while typical production deployments
+run multiple threads in one or more uwsgi/gunicorn processes.
+"""
+
+
+def get_listener() -> QueueListener | None:
+    # Test helper to inspect the listener state.
+    return _listener
+
+
+def ensure_listener(*handlers: logging.Handler, _defer: bool) -> queue.Queue:
+    """
+    Ensure a listener thread is running for :class:`StructlogQueueHandler`.
+
+    Creates a queue if it doesn't exist yet, and starts the background thread to
+    listen to the queue to actually process the log records.
+
+    We don't bother with preventing a background thread in the main runserver process
+    that reloads the code and restarts the server - we don't expect any audit logs to
+    be created there, and trying to detect these situations is too fragile compared
+    to real uwsgi servers & management command situations. The idle background thread
+    should not cause significant overhead.
+
+    :arg _defer: Defer starting the background tread or not - by default on uwsgi we
+      defer the startup and call te actual startup in te post fork hook.
+    """
+    global _listener, _queue
+
+    def _ensure_listener(*args, **kwargs):
+        return ensure_listener(*handlers, _defer=False)
+
+    # we can't reliably use os.register_at_fork as it requires uwsgi's
+    # py-call-uwsgi-fork-hooks flag, which can cause segfaults on Python 3.12:
+    # https://github.com/unbit/uwsgi/issues/2738
+    if _defer and uwsgi is not None:  # pragma: no cover
+        postfork(_ensure_listener)
+
+    # similar to uwsgi postfork, bind a handler when a celery worker process has
+    # initialized
+    try:  # pragma: no cover - no celery dependency available
+        worker_process_init = import_string("celery.signals.worker_process_init")
+        worker_process_init.connect(weak=False)(_ensure_listener)
+    # Celery is an optional dependency
+    except ImportError:
+        pass
+
+    # if a listener already exists, or if we must defer, short circuit and return the
+    # queue already
+    if _defer or _listener is not None:
+        return _queue
+
+    with _lock:
+        _listener = QueueListener(_queue, *handlers, respect_handler_level=True)
+        _listener.start()
+        atexit.register(_stop_listener)
+        return _queue
+
+
+def _stop_listener():
+    """
+    Shut down (and drain) the listener thread/queue.
+    """
+    global _listener
+
+    with _lock:
+        if _listener is None:
+            return
+        try:
+            _listener.stop()  # drains the queue before stopping
+        finally:
+            _listener = None
+
+
+@contextmanager
+def supress_errors():
+    """
+    Ensure that failing to save the logs does not crash the entire application.
+
+    XXX: should we add explicit transaction savepoint so we can recover when running in
+    the main thread?
+    """
+    try:
+        yield
+    except Exception as exc:
+        logger.error("log_saving_failed", exc_info=exc)
+
+
+class StructlogQueueHandler(QueueHandler):
+    """
+    Keep structlog log.record dict as a dict.
+
+    The stdlib implementation by default formats the log record to a string and clears
+    most attributes to make them pickleable.
+    """
+
+    def prepare(self, record: logging.LogRecord):
+        assert is_event_dict(record.msg), "Only structlog event dicts are expected"
+        return record
+
+
+class TimelineLoggerHandler(logging.Handler):
+    """
+    Save a log record into a django-timeline-logger record.
+
+    Logs saved to the local database are typically intended to be easily accessible,
+    e.g. audit logs, without requiring access to a dedicated log storage like Loki.
+
+    This handler goes hand-in-hand with structlog:
+
+    * it looks at the structlog event to call additional (pre)-processing, allowing
+      additional metadata extraction
+    * the additional log attributes are stored as structured data
+
+    The handler keeps an internal buffer to optimize log record insert. The drawback of
+    this is that there may be substantial lag for some log records to be written to the
+    database, as either new log records need to arrive or the handler shutdown needs to
+    be triggered to force another flush. If this is not acceptable, set the buffer size
+    to 1 to force instant flushes.
+
+    :arg adapter: The adapter function that takes a structlog event dict and converts
+      it into something that speaks :class:`timeline_logger.typing.EventDetailsProtocol`
+      understood by the timeline logger handler.
+    :arg use_queue_mode: Marker for queue/direct mode. In direct mode, the buffer size
+      is capped at ``1`` and old database connections are not closed.
+    :arg buffer_size: Maximum size for the internal buffer. Once the number of log
+      records is equal to or exceeds this, they will be written to the database. Until
+      that time the records only exist in memory.
+    :arg flush_interval: Maximum age between database writes. If the buffer is not full
+      yet, but ``flush_interval`` has elapsed since the last write, flush the buffer
+      anyway.
+    """
+
+    buffer: list[TimelineLog]
+
+    def __init__(
+        self,
+        *,
+        adapter: Adapter,
+        use_queue_mode: bool = False,
+        buffer_size: int = 5,
+        flush_interval: float = 3.0,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self.adapter = adapter
+
+        # store configuration options
+        self.use_queue_mode = use_queue_mode
+        self.buffer_size = buffer_size if use_queue_mode else 1
+        self.flush_interval = flush_interval
+
+        # track internal buffer state
+        self.buffer = []
+        self._last_flush = time.monotonic()
+
+    @supress_errors()
+    def emit(self, record: logging.LogRecord):
+        from .models import TimelineLog
+
+        if settings.TIMELINE_HANDLER_DISABLED:
+            return
+
+        assert is_event_dict(record.msg), "Only structlog event dicts are expected"
+
+        self._maybe_close_old_connections()
+        event_details = self.adapter(record.msg)
+        if event_details is None:
+            return
+
+        # create DB record
+        # TODO: validate that the provided template name exists!
+        self.buffer.append(
+            TimelineLog(
+                content_object=event_details.instance,
+                template=event_details.get_template_name(),
+                extra_data=event_details.get_extra_data(),
+                user=event_details.get_user(),
+            )
+        )
+
+        # check if we need to flush the buffer
+        now = time.monotonic()
+        if (
+            len(self.buffer) >= self.buffer_size
+            or (now - self._last_flush) > self.flush_interval
+        ):
+            self._flush()
+
+    def _flush(self):
+        """
+        Flush the buffer to the database.
+        """
+        from .models import TimelineLog
+
+        TimelineLog.objects.bulk_create(self.buffer)
+        self.buffer = []
+        self._last_flush = time.monotonic()
+        self._maybe_close_old_connections()
+
+    def _maybe_close_old_connections(self) -> None:
+        # when running in a separate thread, clean up old connections. Because the
+        # connection lives in its own thread, it doesn't get cleaned up by django's
+        # 'request_finished' signal, so we must manually schedule the cleanup. Django
+        # will re-open the connection when queries are made.
+        if self.use_queue_mode:
+            close_old_connections()
+
+    def close(self):
+        try:
+            self._flush()
+        finally:
+            self._maybe_close_old_connections()
+            super().close()
+
+
+def timeline_handler_factory(
+    *, adapter: Adapter, buffer_size: int = 5, flush_interval: float = 3.0
+) -> StructlogQueueHandler | TimelineLoggerHandler:
+    """
+    Create a logging handler instance suitable for production or testing.
+
+    By default, a queue-based handler is configured so that the actual logging of
+    messages can be offloaded to a worker thread. This improves performance by taking
+    database queries out of the main thread, and improves log integrity because the
+    log insertions run in a separate thread and associated database transaction.
+
+    However, in (unit) test setups, you want to force the logs to be written in the same
+    test transaction so that at the end of the test, the log record creation is rolled
+    back by the test transaction, otherwise you break test isolation substantially
+    and/or slow down test suites considerably by forcing them to be
+    :class:`django.test.TransactionTestCase`.
+
+    The appropriate handler is selected based on the ``TIMELINE_HANDLER_USE_QUEUE``
+    Django setting.
+
+    Note that you cannot change this setup at runtime in tests through
+    :func:`django.test.override_settings`, as the logging config does not get
+    reinitialized when settings change (as it should be!). You should configure CI/local
+    test environments to apply conditional configurations.
+
+    :arg adapter: The adapter function that takes a structlog event dict and converts
+      it into something that speaks :class:`timeline_logger.typing.EventDetailsProtocol`
+      understood by the timeline log handler.
+    :arg buffer_size: Maximum size for the internal buffer. Passed along to the
+      :class:`TimelineLoggerHandler` initializer.
+    :arg flush_interval: Maximum age between database writes. Passed along to the
+      :class:`TimelineLoggerHandler` initializer.
+    """
+    use_queue: bool = settings.TIMELINE_HANDLER_USE_QUEUE
+    timeline_logger_handler = TimelineLoggerHandler(
+        adapter=adapter,
+        use_queue_mode=use_queue,
+        buffer_size=buffer_size,
+        flush_interval=flush_interval,
+    )
+
+    # if the project does not opt out of the queue, return the handler as-is which will
+    # run in the main thread
+    if not use_queue:
+        return timeline_logger_handler
+
+    # otherwise set up the queue system. First, check if we explicitly opt-out of
+    # deferred queue listener start.
+    _defer: bool
+    # Using an environment variable is the most robust way to defer in celery workers.
+    match os.environ.get("_TIMELINE_LOGGER_DEFER_LISTENER", "").lower():
+        case "false" | "0":
+            _defer = False
+        case "true" | "1":
+            _defer = True
+        case _:  # pragma: no cover
+            _defer = uwsgi is not None
+
+    queue = ensure_listener(timeline_logger_handler, _defer=_defer)
+    return StructlogQueueHandler(queue=queue)

--- a/timeline_logger/handlers.py
+++ b/timeline_logger/handlers.py
@@ -25,7 +25,6 @@ import queue
 import threading
 import time
 from collections.abc import Callable
-from contextlib import contextmanager
 from logging.handlers import QueueHandler, QueueListener
 from typing import TYPE_CHECKING, Any
 
@@ -155,20 +154,6 @@ def _stop_listener():
             _listener = None
 
 
-@contextmanager
-def supress_errors():
-    """
-    Ensure that failing to save the logs does not crash the entire application.
-
-    XXX: should we add explicit transaction savepoint so we can recover when running in
-    the main thread?
-    """
-    try:
-        yield
-    except Exception as exc:
-        logger.error("log_saving_failed", exc_info=exc)
-
-
 class StructlogQueueHandler(QueueHandler):
     """
     Keep structlog log.record dict as a dict.
@@ -238,8 +223,19 @@ class TimelineLoggerHandler(logging.Handler):
         self.buffer = []
         self._last_flush = time.monotonic()
 
-    @supress_errors()
     def emit(self, record: logging.LogRecord):
+        try:
+            self._emit_to_db(record)
+        except Exception as exc:
+            self.handleError(record)
+
+            # XXX: should we add explicit transaction savepoint so we can recover when
+            # running in the main thread?
+            logger.error("log_saving_failed", exc_info=exc)
+            if on_error := settings.TIMELINE_HANDLER_ON_ERROR:
+                on_error(exc)
+
+    def _emit_to_db(self, record: logging.LogRecord):
         from .models import TimelineLog
 
         if settings.TIMELINE_HANDLER_DISABLED:

--- a/timeline_logger/typing.py
+++ b/timeline_logger/typing.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping
+from typing import TYPE_CHECKING, Any, Protocol
+
+from django.db import models
+
+from typing_extensions import TypeIs
+
+if TYPE_CHECKING:
+    from django.contrib.auth.base_user import AbstractBaseUser
+
+
+type EventDict = MutableMapping[str, Any]
+"""
+Structlog's ``EventDict`` type, vendored to avoid a dependency.
+
+See upstream: https://github.com/hynek/structlog/blob/811245fe02fcf454f517f0677648457bfec52ef0/src/structlog/typing.py#L57
+"""
+
+
+class EventDetailsProtocol[U: AbstractBaseUser](Protocol):
+    """
+    Dataclass or similar that can provide the timeline logger event details.
+    """
+
+    instance: models.Model
+
+    def get_template_name(self) -> str: ...
+    def get_user(self) -> U | None: ...
+    def get_extra_data(self) -> Mapping[str, object]: ...
+
+
+class Adapter(Protocol):
+    def __call__(self, event_dict: EventDict) -> EventDetailsProtocol | None: ...
+
+
+def is_event_dict(msg: str | Any) -> TypeIs[EventDict]:
+    """
+    Test if the provided log record message is an event dict.
+    """
+    return isinstance(msg, dict)


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#5351

The real handler is expected to be passed as argument to the ensure_listener helper, which passes the queue to use for log message exchange across threads.

The handler is ready for usage in uwsgi/celery contexts so that the background thread start is deferred until after the process has forked, otherwise we end up in race conditions and/or deadlocks as threads don't survive forks (while queues apparently do).

Note that the queue is unbounded - this *may* pose a problem if much more log events are produced before they can be processed. We'll have to keep an eye on things and put guard rails/monitoring in place. This would however not be normal operation, as without queue/thread, this would actually slow down the application considerably when it's perform sync in the main thread.